### PR TITLE
docs: Add attention comment when use npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ MarkdownをHTML変換してPuppeteerでPDF化。
 npm install
 ```
 
+**バージョン指定しないとpdf化されないので、package-lock.jsonそのままで`npm`で動かす。**
+
 `config.json`を編集。
 
 - `template`: Markdown変換後のHTMLテンプレートファイルパス（Mustache形式）


### PR DESCRIPTION
# What
- Add attention comment for using `npm install` or `yarn install`

# Why
Maybe npm package is dependent specific version.
I can't convert pdf when `yarn install`.